### PR TITLE
Add CI for go

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 
 # Go files
 [*.go]
-indent_style = space
+indent_style = tab
 indent_size = 2
 max_line_length = 120
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: Go CI
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build
+        run: go build -v ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: greut/eclint-action@v0
+
+  test:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Test
+        run: go test -v ./...


### PR DESCRIPTION
Zur kontinuierlichen Verbesserung unserer Software soll die CI sicherstellen, dass durch Anpassungen der Quellcode immer funktionstüchtig ist.